### PR TITLE
chore(mapping): Remove rustfmt

### DIFF
--- a/lua/mason-conform/mapping.lua
+++ b/lua/mason-conform/mapping.lua
@@ -96,7 +96,7 @@ M.conform_to_package = {
     ["ruff_fix"] = "ruff",
     ["ruff_format"] = "ruff",
     ["rufo"] = "rufo",
-    ["rustfmt"] = "rustfmt",
+    -- ["rustfmt"] = "rustfmt", Deprecated by mason
     ["rustywind"] = "rustywind",
     -- scalafmt
     ["shellcheck"] = "shellcheck",


### PR DESCRIPTION
Closes #2 

Mason has marked rustfmt as deprecated, remove the mapping so we stop downloading it.