### PR TITLE
Update conform_to_package mapping

### DIFF
--- a/lua/mason-conform/mapping.lua
+++ b/lua/mason-conform/mapping.lua
@@ -3,7 +3,7 @@ local M = {}
 -- conform formatter to mason package mapping
 -- https://mason-registry.dev/registry/list
 M.conform_to_package = {
-    -- air
+    ["air"] = "air",
     ["alejandra"] = "alejandra",
     ["ansible-lint"] = "ansible-lint",
     ["asmfmt"] = "asmfmt",
@@ -85,7 +85,7 @@ M.conform_to_package = {
     ["goimports"] = "goimports",
     ["goimports-reviser"] = "goimports-reviser",
     -- gojq
-    -- golangci-lint
+    ["golangci-lint"] = "golangci-lint",
     ["golines"] = "golines",
     ["google-java-format"] = "google-java-format",
     -- grain_format
@@ -108,7 +108,7 @@ M.conform_to_package = {
     ["jsonnetfmt"] = "jsonnetfmt",
     -- just
     ["kcl"] = "kcl",
-    -- kdlfmt
+    ["kdlfmt"] = "kdlfmt",
     -- keep-sorted
     ["ktfmt"] = "ktfmt",
     ["ktlint"] = "ktlint",
@@ -132,9 +132,9 @@ M.conform_to_package = {
     -- nginxfmt
     -- nickel; it exists on Mason, but as LSP (exec: `nls`)
     -- nimpretty
-    -- nixfmt
+    ["nixfmt"] = "nixfmt",
     ["nixpkgs_fmt"] = "nixpkgs-fmt",
-    -- nomad_fmt
+    ["nomad_fmt"] = "nomad",
     -- nph
     ["npm-groovy-lint"] = "npm-groovy-lint",
     -- nufmt
@@ -160,7 +160,7 @@ M.conform_to_package = {
     ["purs-tidy"] = "purescript-tidy",
     -- pycln
     ["pyink"] = "pyink",
-    -- pyproject-fmt
+    ["pyproject-fmt"] = "pyproject-fmt",
     -- python-ly
     -- pyupgrade
     ["reformat-gherkin"] = "reformat-gherkin",
@@ -187,7 +187,7 @@ M.conform_to_package = {
     ["sql_formatter"] = "sql-formatter",
     ["sqlfluff"] = "sqlfluff",
     ["sqlfmt"] = "sqlfmt",
-    -- sqruff
+    ["sqruff"] = "sqruff",
     -- squeeze_blanks
     -- standard-clj
     ["standardjs"] = "standardjs",
@@ -204,12 +204,12 @@ M.conform_to_package = {
     -- syntax_tree
     ["taplo"] = "taplo",
     ["templ"] = "templ",
-    -- terraform_fmt
+    ["terraform_fmt"] = "terraform",
     -- terragrunt_hclfmt
     ["tex-fmt"] = "tex-fmt",
     ["tlint"] = "tlint",
     -- tofu_fmt
-    -- tombi
+    ["tombi"] = "tombi",
     -- treefmt
     -- trim_newlines
     -- trim_whitespace

--- a/lua/mason-conform/mapping.lua
+++ b/lua/mason-conform/mapping.lua
@@ -30,6 +30,7 @@ M.conform_to_package = {
     -- cabal_fmt
     -- caramel_fmt
     ["cbfmt"] = "cbfmt",
+    -- cedar
     ["clang-format"] = "clang-format",
     ["cljfmt"] = "cljfmt",
     -- cljstyle
@@ -49,6 +50,7 @@ M.conform_to_package = {
     ["dcm_format"] = "dcm",
     ["deno_fmt"] = "deno",
     -- dfmt
+    -- dioxus
     ["djlint"] = "djlint",
     ["docformatter"] = "docformatter",
     -- docstrfmt
@@ -74,6 +76,7 @@ M.conform_to_package = {
     ["gci"] = "gci",
     ["gdformat"] = "gdtoolkit",
     ["gersemi"] = "gersemi",
+    -- ghokin
     -- gleam
     -- gluon_fmt
     -- gn
@@ -82,11 +85,13 @@ M.conform_to_package = {
     ["goimports"] = "goimports",
     ["goimports-reviser"] = "goimports-reviser",
     -- gojq
+    -- golangci-lint
     ["golines"] = "golines",
     ["google-java-format"] = "google-java-format",
     -- grain_format
     ["hcl"] = "hclfmt",
     -- hindent
+    -- hledger-fmt
     -- html_beautify
     ["htmlbeautifier"] = "htmlbeautifier",
     -- hurlfmt
@@ -96,6 +101,7 @@ M.conform_to_package = {
     -- injected
     -- inko
     ["isort"] = "isort",
+    -- janet-format
     ["joker"] = "joker",
     ["jq"] = "jq",
     -- js_beautify
@@ -103,6 +109,7 @@ M.conform_to_package = {
     -- just
     ["kcl"] = "kcl",
     -- kdlfmt
+    -- keep-sorted
     ["ktfmt"] = "ktfmt",
     ["ktlint"] = "ktlint",
     ["kulala-fmt"] = "kulala-fmt",
@@ -111,6 +118,8 @@ M.conform_to_package = {
     -- liquidsoap-prettier
     -- llf
     ["lua-format"] = "luaformatter",
+    -- mago_format
+    -- mago_lint
     ["markdown-toc"] = "markdown-toc",
     -- markdownfmt
     ["markdownlint"] = "markdownlint",
@@ -131,6 +140,7 @@ M.conform_to_package = {
     -- nufmt
     ["ocamlformat"] = "ocamlformat",
     -- ocp-indent
+    -- odinfmt
     ["opa_fmt"] = "opa",
     ["ormolu"] = "ormolu",
     -- packer_fmt
@@ -148,9 +158,11 @@ M.conform_to_package = {
     ["prettypst"] = "prettypst",
     -- puppet-lint
     ["purs-tidy"] = "purescript-tidy",
+    -- pycln
     ["pyink"] = "pyink",
     -- pyproject-fmt
     -- python-ly
+    -- pyupgrade
     ["reformat-gherkin"] = "reformat-gherkin",
     ["reorder-python-imports"] = "reorder-python-imports",
     -- rescript-format
@@ -185,6 +197,7 @@ M.conform_to_package = {
     -- stylish-haskell
     ["stylua"] = "stylua",
     ["superhtml"] = "superhtml",
+    -- swift
     -- swift_format
     -- swiftformat
     ["swiftlint"] = "swiftlint",
@@ -196,14 +209,18 @@ M.conform_to_package = {
     ["tex-fmt"] = "tex-fmt",
     ["tlint"] = "tlint",
     -- tofu_fmt
+    -- tombi
+    -- treefmt
     -- trim_newlines
     -- trim_whitespace
     ["twig-cs-fixer"] = "twig-cs-fixer",
+    -- typespec
     ["typos"] = "typos",
     -- typstyle
     -- ufmt
     -- uncrustify
     ["usort"] = "usort",
+    -- v
     ["verible"] = "verible",
     ["vsg"] = "vsg",
     ["xmlformat"] = "xmlformatter", -- Deprecated in conform.nvim; redirects to xmlformatter


### PR DESCRIPTION
like #12

This PR adds 9 formatter tools to the conform_to_package mapping by cross-referencing the [Mason registry](https://mason-registry.dev/registry/list) and the [conform.nvim supported formatters list](https://github.com/stevearc/conform.nvim/blob/master/README.md).

**Newly enabled mappings:**
- `air` → `air`
- `golangci-lint` → `golangci-lint` 
- `kdlfmt` → `kdlfmt`
- `nixfmt` → `nixfmt`
- `pyproject-fmt` → `pyproject-fmt`
- `sqruff` → `sqruff`
- `tombi` → `tombi`
- `nomad_fmt` → `nomad` (package name differs)
- `terraform_fmt` → `terraform` (package name differs)

**Also added as commented entries for reference:**
- cedar, dioxus, ghokin, hledger-fmt, janet-format, keep-sorted, mago_format, mago_lint, odinfmt, pycln, pyupgrade, swift, treefmt, typespec, v

Note: Only verified these specific tools exist - did not audit existing uncommented entries for deprecation or correctness.

Thank you for maintaining this plugin!